### PR TITLE
Add passing password via environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ or FITNESS FOR A PARTICULAR PURPOSE.
 
 The default package release version selection pattern is `r".*dev\d+$"`.
 
+Authentication password may be passed via environment variable
+`PYPI_CLEANUP_PASSWORD`. Otherwise, you will be prompted to enter it.
+
 Authentication with TOTP is supported.
 
 Examples:

--- a/src/main/python/pypi_cleanup/__init__.py
+++ b/src/main/python/pypi_cleanup/__init__.py
@@ -17,6 +17,7 @@
 import argparse
 import getpass
 import logging
+import os
 import re
 import sys
 from html.parser import HTMLParser
@@ -123,7 +124,9 @@ class PypiCleanup:
                 if not self.dry_run:
                     return 3
 
-            password = getpass.getpass("Password: ")
+            password = os.getenv("PYPI_CLEANUP_PASSWORD")
+            if password is None:
+                password = getpass.getpass("Password: ")
 
             with s.get(f"{self.url}/account/login/") as r:
                 r.raise_for_status()


### PR DESCRIPTION
Your package is awesome! But it's impossible to use it from gradle or other buildsystems because of `getpass()` call, it is not even a standard stdio. So, I've added alternative way of passing password to make it absolutely ideal.