### PR TITLE
fix issue with the dry_run/do_it argument

### DIFF
--- a/src/main/python/pypi_cleanup/__init__.py
+++ b/src/main/python/pypi_cleanup/__init__.py
@@ -210,13 +210,13 @@ def main():
     parser.add_argument("-t", "--host", default="https://pypi.org/", dest="url", help="PyPI <proto>://<host> prefix")
     parser.add_argument("-r", "--version-regex", type=re.compile, action="append",
                         dest="patterns", help="regex to use to match package versions to be deleted")
-    parser.add_argument("--do-it", action="store_true", default=False, help="actually perform the destructive delete")
+    parser.add_argument("--do-it", action="store_true", default=False, dest="do_it", help="actually perform the destructive delete")
     parser.add_argument("-y", "--yes", action="store_true", default=False, dest="confirm",
                         help="confirm extremely dangerous destructive delete")
     parser.add_argument("-v", "--verbose", action="store_const", const=1, default=0, help="be verbose")
 
     args = parser.parse_args()
-    if args.patterns and not args.confirm and not args.dry_run:
+    if args.patterns and not args.confirm and not args.do_it:
         logging.warning(dedent(f"""
         WARNING:
         \tYou're using custom patterns: {args.patterns}.


### PR DESCRIPTION
Hello,

First of all, thank you for your very convenient package, Pypi's interface being terrible for removing multiple ones.

I had an issue when using custom regex, the condition line 219 was looking for an undefined argument _dry\_run_ (probably a relic from the version 0.0.3).

I added a _dest_ for the corresponding variable few lines above and called it _do\_it_ to match with the other calls later on.