### PR TITLE
Allow dry runs with custom regexes.

### DIFF
--- a/src/main/python/pypi_cleanup/__init__.py
+++ b/src/main/python/pypi_cleanup/__init__.py
@@ -224,9 +224,7 @@ def main():
         \tIf you make a mistake in your patterns you can potentially wipe critical versions irrecoverably.
         \tMake sure to test your patterns before running the destructive cleanup.
         \tOnce you're satisfied the patterns are correct re-run with `-y`/`--yes` to confirm you know what you're doing.
-        \tGoodbye.
         \t"""))
-        return 3
 
     return PypiCleanup(**vars(args)).run()
 


### PR DESCRIPTION
Previously, if custom regexes were specified and we were in "dry-run" (I.e., not `-y --do-it`) mode, the code would exist
with a warning about checking the regexes carefully. But it is precisely the  "dry run" mode that is helpful in 
checking those regexes! 

This change retains the warning but allows the dry run to continue - after all it is not the thing the warning is
warning about. It is the "wet run" that is potentially dangerous, and the dry run is what helps mitigate that risk.