### PR TITLE
Switch to PEP 691 for version and release information

### DIFF
--- a/.github/workflows/pypi-cleanup.yml
+++ b/.github/workflows/pypi-cleanup.yml
@@ -14,14 +14,14 @@ jobs:
         os:
           - ubuntu-latest
         python-version:
-          - '3.11.0-rc.1'
+          - '3.12'
+          - '3.11'
           - '3.10'
           - '3.9'
           - '3.8'
           - '3.7'
-          - '3.6'
     env:
-      DEPLOY_PYTHONS: "3.10"
+      DEPLOY_PYTHONS: "3.12"
       DEPLOY_OSES: "Linux"
       TWINE_USERNAME: __token__
       TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![PyPI Cleanup Version](https://img.shields.io/pypi/v/pypi-cleanup?logo=pypi)](https://pypi.org/project/pypi-cleanup/)
 [![PyPI Cleanup Python Versions](https://img.shields.io/pypi/pyversions/pypi-cleanup?logo=pypi)](https://pypi.org/project/pypi-cleanup/)
-[![Build Status](https://img.shields.io/github/workflow/status/arcivanov/pypi-cleanup/pypi-cleanup/master)](https://github.com/arcivanov/pypi-cleanup/actions/workflows/pypi-cleanup.yml)
+[![Build Status](https://img.shields.io/github/actions/workflow/status/arcivanov/pypi-cleanup/pypi-cleanup.yml?branch=master)](https://github.com/arcivanov/pypi-cleanup/actions/workflows/pypi-cleanup.yml)
 [![PyPI Cleanup Downloads Per Day](https://img.shields.io/pypi/dd/pypi-cleanup?logo=pypi)](https://pypi.org/project/pypi-cleanup/)
 [![PyPI Cleanup Downloads Per Week](https://img.shields.io/pypi/dw/pypi-cleanup?logo=pypi)](https://pypi.org/project/pypi-cleanup/)
 [![PyPI Cleanup Downloads Per Month](https://img.shields.io/pypi/dm/pypi-cleanup?logo=pypi)](https://pypi.org/project/pypi-cleanup/)

--- a/build.py
+++ b/build.py
@@ -37,7 +37,7 @@ urls = {"Bug Tracker": "https://github.com/arcivanov/pypi-cleanup/issues",
         "Documentation": "https://github.com/arcivanov/pypi-cleanup"
         }
 
-requires_python = ">=3.6"
+requires_python = ">=3.7"
 
 default_task = ["analyze", "publish"]
 
@@ -67,11 +67,12 @@ def set_properties(project):
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Operating System :: MacOS :: MacOS X",
         "Operating System :: POSIX :: Linux",
         "Operating System :: Microsoft :: Windows",


### PR DESCRIPTION
Add testing on Python 3.11 and 3.12, fix README
Improve logging consistency
Print versions to be deleted prior to authentication
Move timeout pause after the authentication immediately
prior to destructive action
Increase timeout pause from 3 to 5s
Remove Python 3.6 support as it's gone from testing images

fixes #21