### PR TITLE
Fix ValueError when package version has no matching files

### DIFF
--- a/src/main/python/pypi_cleanup/__init__.py
+++ b/src/main/python/pypi_cleanup/__init__.py
@@ -134,10 +134,11 @@ class PypiCleanup:
                         return filename in (f"{p}-{v}.tar.gz", f"{p}-{v}.zip")
 
                     for version in project_info["versions"]:
-                        releases_by_date[version] = max(
-                            [datetime.datetime.strptime(f["upload-time"], "%Y-%m-%dT%H:%M:%S.%f%z")
+                        matches = [datetime.datetime.strptime(f["upload-time"], "%Y-%m-%dT%H:%M:%S.%f%z")
                              for f in project_info["files"]
-                             if package_matches_file(package, version, f)])
+                             if package_matches_file(package, version, f)]
+                        if len(matches) > 0:
+                            releases_by_date[version] = max(matches)
 
                 if not releases_by_date:
                     logging.info(f"No releases for package {package!r} have been found")

--- a/src/main/python/pypi_cleanup/__init__.py
+++ b/src/main/python/pypi_cleanup/__init__.py
@@ -136,9 +136,9 @@ class PypiCleanup:
 
                     for version in project_info["versions"]:
                         matches = [datetime.datetime.strptime(f["upload-time"], "%Y-%m-%dT%H:%M:%S.%f%z")
-                             for f in project_info["files"]
-                             if package_matches_file(package, version, f)]
-                        if len(matches) > 0:
+                                   for f in project_info["files"]
+                                   if package_matches_file(package, version, f)]
+                        if matches:
                             releases_by_date[version] = max(matches)
 
                 if not releases_by_date:

--- a/src/unittest/python/pypi_cleanup_tests.py
+++ b/src/unittest/python/pypi_cleanup_tests.py
@@ -13,3 +13,74 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
+
+import unittest
+from unittest.mock import Mock, patch, MagicMock
+from pypi_cleanup import PypiCleanup
+
+
+class TestEmptyMatchesListRegression(unittest.TestCase):
+    """
+    Regression test for the bug where max() is called on an empty list when
+    a package version has no matching files based on the package_matches_file filter.
+
+    This can happen when a package has versions listed but the files don't match
+    the expected naming patterns (e.g., .whl, .tar.gz, .zip with correct naming).
+
+    Bug: ValueError: max() arg is an empty sequence
+    """
+
+    @patch('pypi_cleanup.requests.Session')
+    def test_version_with_no_matching_files_does_not_crash(self, mock_session):
+        """
+        Test that when a version has files but none match the expected patterns,
+        the code doesn't crash with ValueError from max() on empty list.
+        """
+        # Mock the session and response
+        mock_session_instance = MagicMock()
+        mock_session.return_value.__enter__.return_value = mock_session_instance
+
+        # Mock response for package query with a version that has no matching files
+        mock_response = Mock()
+        mock_response.json.return_value = {
+            "name": "test-package",
+            "versions": ["1.0.0"],
+            "files": [
+                # Files that won't match the package_matches_file filter
+                {
+                    "filename": "wrongname-1.0.0.tar.gz",  # Wrong package name
+                    "upload-time": "2024-01-01T12:00:00.000000+00:00"
+                }
+            ]
+        }
+        mock_response.raise_for_status = Mock()
+        mock_session_instance.get.return_value.__enter__.return_value = mock_response
+
+        # Create PypiCleanup instance in query-only mode (no auth needed)
+        cleanup = PypiCleanup(
+            url="https://test.pypi.org",
+            username=None,
+            packages=["test-package"],
+            do_it=False,
+            patterns=None,
+            verbose=False,
+            days=0,
+            query_only=True,
+            leave_most_recent_only=False,
+            confirm=False,
+            delete_project=False
+        )
+
+        # This should not raise ValueError from max() on empty list
+        try:
+            result = cleanup.run()
+            # In query-only mode with no matching releases, it should return None
+            self.assertIsNone(result)
+        except ValueError as e:
+            if "max() arg is an empty sequence" in str(e):
+                self.fail("max() was called on empty list - bug not fixed!")
+            raise
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
I discovered this issue while running: `pypi-cleanup -p pulumi-oci` with Python 3.13.9.

When a package version exists but has no files matching the expected naming patterns (e.g., .whl, .tar.gz, .zip with correct package-version prefix), the code would attempt to call max() on an empty list, causing a ValueError: max() arg is an empty sequence.

This fix checks if the matches list is non-empty before calling max(), which prevents the crash when processing packages like pulumi-oci.

Also adds a regression test to verify the fix.

**Disclaimer:** The test has been AI-generated, but not the fix. I verified the test fails in `master` (project's `main` branch), but it no longer fails on the PR branch.