### PR TITLE
Add release app token for branch protection bypass

### DIFF
--- a/.github/workflows/pypi-cleanup.yml
+++ b/.github/workflows/pypi-cleanup.yml
@@ -36,6 +36,8 @@ jobs:
             ${{ github.event_name == 'push'
             && contains(env.DEPLOY_OSES, runner.os)
             && contains(env.DEPLOY_PYTHONS, matrix.python-version) }}
+          release-app-id: ${{ secrets.PYBUILDER_RELEASE_APP_ID }}
+          release-app-private-key: ${{ secrets.PYBUILDER_RELEASE_APP_PRIVATE_KEY }}
   build-stable-summary:
     if: success() || failure()
     runs-on: ubuntu-latest


### PR DESCRIPTION
Pass pybuilder-release GitHub App credentials to pybuilder/build action for bypassing branch protection during release automation.